### PR TITLE
Feature: View binary XLS files

### DIFF
--- a/xls.html
+++ b/xls.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Roundcube WebODF Viewer</title>
+<style type="text/css" media="screen">
+
+    body, div {
+        padding: 0px;
+        margin: 0px;
+        border: 0px;
+        background: #fff;
+    }
+    body.odfcanvas {
+        height: 100%;
+        color: white;
+        background: darkgrey;
+        text-align: center;
+    }
+
+</style>
+<link rel="stylesheet" type="text/css" href="%%DOCROOT%%webodf.css"/>
+</head>
+
+<body class="odfcanvas">
+    <div id="odf"></div>
+</body>
+</html>


### PR DESCRIPTION
- the xlhtml shell command is able to quickly parse a binary XLS into a HTML table, if it is present, we add the extra mimetype, and allow to display the resulting HTML table
- Added the HTML template for the XLS display